### PR TITLE
Update readme with direct git link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # sqlalchemy-seedify
+
+## Installation
+
+Le paquet n'est pas publié sur PyPI pour le moment. Installez-le directement depuis GitHub. L'URL **HTTPS** est recommandée pour une installation en lecture seule sans configuration de clés SSH.
+
+### Avec pip
+
+```bash
+pip install git+https://github.com/L-Empire-des-jouets/sqlalchemy-seedify.git
+```
+
+### Avec uv
+
+```bash
+uv add git+https://github.com/L-Empire-des-jouets/sqlalchemy-seedify.git
+```
+
+> Remarque: si vous préférez utiliser SSH et que vos clés GitHub sont configurées, vous pouvez substituer l'URL HTTPS par l'URL SSH.


### PR DESCRIPTION
Update `README.md` installation instructions to use direct Git URL, as the package is not yet published on PyPI.

The previous instructions for `pip install sqlalchemy-seedify` and `uv add sqlalchemy-seedify` were incorrect because the package is not available on PyPI. This PR updates them to use the direct Git HTTPS URL, which is recommended for public, read-only installations without requiring SSH key setup.

---
<a href="https://cursor.com/background-agent?bcId=bc-4eb13bab-9319-4df7-90d5-21eca8b78be9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4eb13bab-9319-4df7-90d5-21eca8b78be9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

