### PR TITLE
Integrate sqlalchemy seeder into fastapi

### DIFF
--- a/alembic-seeder/CHANGELOG.md
+++ b/alembic-seeder/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [1.1.0] - 2025-09-28
+
+### Added
+- Content-hash tracking for seeders (code + metadata) to detect changes and skip up-to-date seeders
+- `content_hash` column and index in tracking table; migration template updated
+- `UpsertManager` extracted and exported; `BaseSeeder` delegates idempotence helpers
+- CLI: `--fresh` option to clear history and re-run all; status shows changed seeders and hashes (detailed)
+
+### Improved
+- Registry import resilience for seeders located outside `sys.path`
+- Manager records execution_time and records_affected in tracker
+
 # Changelog
 
 All notable changes to Alembic Seeder will be documented in this file.

--- a/alembic-seeder/README.md
+++ b/alembic-seeder/README.md
@@ -13,6 +13,7 @@ A comprehensive seeder system for Alembic and SQLAlchemy, inspired by Laravel's 
 - **Dependency Resolution**: Define dependencies between seeders with automatic ordering
 - **Rollback Support**: Undo seeder operations when needed
 - **Tracking System**: Keep track of which seeders have been executed
+- **Content Hashing**: Detect changed seeders via code+metadata hash; skip up-to-date seeders
 - **CLI Integration**: Seamless integration with Alembic commands
 - **Batch Operations**: Execute seeders in batches for better organization
 - **Dry Run Mode**: Preview what will be executed without making changes
@@ -208,6 +209,9 @@ alembic-seeder run --seeder UserSeeder --seeder ProductSeeder
 # Force re-run
 alembic-seeder run --force
 
+# Fresh run (clear tracking, then run all)
+alembic-seeder run --fresh
+
 # Dry run
 alembic-seeder run --dry-run
 
@@ -362,6 +366,7 @@ The tracking table (`alembic_seeder_history`) stores:
 - Batch number
 - Records affected
 - Status and error messages
+ - Content hash (sha256) for change detection
 
 ## 🧪 Testing
 

--- a/alembic-seeder/pyproject.toml
+++ b/alembic-seeder/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "alembic-seeder"
-version = "1.0.0"
+version = "1.1.0"
 description = "A comprehensive seeder system for Alembic and SQLAlchemy, inspired by Laravel seeders"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/alembic-seeder/src/alembic_seeder/__init__.py
+++ b/alembic-seeder/src/alembic_seeder/__init__.py
@@ -10,6 +10,7 @@ from alembic_seeder.core.seeder_manager import SeederManager
 from alembic_seeder.core.seeder_registry import SeederRegistry
 from alembic_seeder.tracking.tracker import SeederTracker
 from alembic_seeder.utils.environment import EnvironmentManager
+from alembic_seeder.core.upsert_manager import UpsertManager
 
 __version__ = "1.1.0"
 
@@ -19,4 +20,5 @@ __all__ = [
     "SeederRegistry",
     "SeederTracker",
     "EnvironmentManager",
+    "UpsertManager",
 ]

--- a/alembic-seeder/src/alembic_seeder/commands/init_command.py
+++ b/alembic-seeder/src/alembic_seeder/commands/init_command.py
@@ -113,15 +113,18 @@ def upgrade():
         sa.Column('status', sa.String(length=20), nullable=False),
         sa.Column('error_message', sa.Text(), nullable=True),
         sa.Column('metadata_json', sa.Text(), nullable=True),
+        sa.Column('content_hash', sa.String(length=64), nullable=True),
         sa.PrimaryKeyConstraint('id'),
         sa.UniqueConstraint('seeder_name', 'environment', name='uq_seeder_env')
     )
     op.create_index(op.f('ix_alembic_seeder_history_batch'), 'alembic_seeder_history', ['batch'], unique=False)
     op.create_index(op.f('ix_alembic_seeder_history_environment'), 'alembic_seeder_history', ['environment'], unique=False)
     op.create_index(op.f('ix_alembic_seeder_history_seeder_name'), 'alembic_seeder_history', ['seeder_name'], unique=False)
+    op.create_index(op.f('ix_alembic_seeder_history_content_hash'), 'alembic_seeder_history', ['content_hash'], unique=False)
 
 
 def downgrade():
+    op.drop_index(op.f('ix_alembic_seeder_history_content_hash'), table_name='alembic_seeder_history')
     op.drop_index(op.f('ix_alembic_seeder_history_seeder_name'), table_name='alembic_seeder_history')
     op.drop_index(op.f('ix_alembic_seeder_history_environment'), table_name='alembic_seeder_history')
     op.drop_index(op.f('ix_alembic_seeder_history_batch'), table_name='alembic_seeder_history')

--- a/alembic-seeder/src/alembic_seeder/core/__init__.py
+++ b/alembic-seeder/src/alembic_seeder/core/__init__.py
@@ -3,5 +3,6 @@
 from .base_seeder import BaseSeeder
 from .seeder_manager import SeederManager
 from .seeder_registry import SeederRegistry
+from .upsert_manager import UpsertManager
 
-__all__ = ["BaseSeeder", "SeederManager", "SeederRegistry"]
+__all__ = ["BaseSeeder", "SeederManager", "SeederRegistry", "UpsertManager"]

--- a/alembic-seeder/src/alembic_seeder/core/upsert_manager.py
+++ b/alembic-seeder/src/alembic_seeder/core/upsert_manager.py
@@ -1,0 +1,139 @@
+"""
+Dedicated utilities for idempotent data operations.
+
+This class encapsulates upsert logic to keep BaseSeeder concise and focused
+on lifecycle. It operates on a provided SQLAlchemy session.
+"""
+
+from typing import Any, Dict, List, Optional, Type
+
+from sqlalchemy import and_, or_
+from sqlalchemy.orm import Session
+
+
+class UpsertManager:
+    def __init__(self, session: Session):
+        self.session = session
+
+    def get_or_create(
+        self,
+        model: Type[Any],
+        where: Dict[str, Any],
+        defaults: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        instance = self.session.query(model).filter_by(**where).first()
+        if instance:
+            return instance, False
+
+        payload: Dict[str, Any] = {}
+        if defaults:
+            payload.update(defaults)
+        payload.update(where)
+
+        instance = model(**payload)
+        self.session.add(instance)
+        self.session.flush()
+        return instance, True
+
+    def upsert(
+        self,
+        model: Type[Any],
+        where: Dict[str, Any],
+        values: Dict[str, Any],
+        update_existing: bool = True,
+    ) -> Any:
+        instance = self.session.query(model).filter_by(**where).first()
+        if not instance:
+            payload = {**where, **values}
+            instance = model(**payload)
+            self.session.add(instance)
+            self.session.flush()
+            return instance, "created"
+
+        if not update_existing:
+            return instance, "unchanged"
+
+        changed = False
+        for field, new_value in values.items():
+            current_value = getattr(instance, field, None)
+            if current_value != new_value:
+                setattr(instance, field, new_value)
+                changed = True
+
+        if changed:
+            self.session.flush()
+            return instance, "updated"
+
+        return instance, "unchanged"
+
+    def bulk_upsert(
+        self,
+        model: Type[Any],
+        rows: List[Dict[str, Any]],
+        key_fields: List[str],
+        update_fields: Optional[List[str]] = None,
+    ) -> Dict[str, int]:
+        if not rows:
+            return {"created": 0, "updated": 0, "unchanged": 0}
+
+        # Prepare key tuples
+        key_tuples = []
+        for row in rows:
+            key_tuples.append(tuple(row[k] for k in key_fields))
+
+        # Build filters to fetch all existing in one go
+        filters = []
+        for key_values in key_tuples:
+            clauses = []
+            for idx, field in enumerate(key_fields):
+                clauses.append(getattr(model, field) == key_values[idx])
+            filters.append(and_(*clauses))
+
+        existing_by_key: Dict[tuple, Any] = {}
+        if filters:
+            existing = self.session.query(model).filter(or_(*filters)).all()
+            for obj in existing:
+                key = tuple(getattr(obj, f) for f in key_fields)
+                existing_by_key[key] = obj
+
+        created_count = 0
+        updated_count = 0
+        unchanged_count = 0
+
+        for row in rows:
+            key = tuple(row[k] for k in key_fields)
+            obj = existing_by_key.get(key)
+            if obj is None:
+                obj = model(**row)
+                self.session.add(obj)
+                created_count += 1
+                existing_by_key[key] = obj
+                continue
+
+            # Determine fields to update
+            fields_to_update = (
+                [f for f in row.keys() if f not in key_fields]
+                if update_fields is None
+                else [f for f in update_fields if f in row]
+            )
+
+            changed = False
+            for field in fields_to_update:
+                new_value = row[field]
+                if getattr(obj, field, None) != new_value:
+                    setattr(obj, field, new_value)
+                    changed = True
+
+            if changed:
+                updated_count += 1
+            else:
+                unchanged_count += 1
+
+        self.session.flush()
+
+        return {
+            "created": created_count,
+            "updated": updated_count,
+            "unchanged": unchanged_count,
+        }
+

--- a/alembic-seeder/src/alembic_seeder/tracking/hash.py
+++ b/alembic-seeder/src/alembic_seeder/tracking/hash.py
@@ -1,0 +1,57 @@
+"""
+Utilities to compute deterministic content hashes for seeders.
+"""
+
+import hashlib
+import inspect
+import json
+from typing import Type
+
+from alembic_seeder.core.base_seeder import BaseSeeder
+
+
+def compute_seeder_content_hash(seeder_class: Type[BaseSeeder]) -> str:
+    """
+    Compute a stable hash representing the seeder's effective content.
+
+    The hash includes:
+    - Source of the seeder class `run` method
+    - Source of the optional `rollback` method if supported
+    - Seeder metadata returned by `_get_metadata()` (as a sorted JSON)
+
+    Returns a lowercase hex digest (sha256).
+    """
+    sha = hashlib.sha256()
+
+    # Method sources
+    try:
+        run_src = inspect.getsource(seeder_class.run)
+    except Exception:
+        run_src = ""
+    sha.update(run_src.encode("utf-8"))
+
+    # Include rollback method source if overridden
+    try:
+        # Only include if the class overrides BaseSeeder.rollback
+        if seeder_class.rollback is not BaseSeeder.rollback:
+            rb_src = inspect.getsource(seeder_class.rollback)
+            sha.update(rb_src.encode("utf-8"))
+    except Exception:
+        pass
+
+    # Metadata (sorted JSON for stability)
+    try:
+        metadata = seeder_class._get_metadata()
+        # Pydantic v2: model_dump
+        meta_dict = metadata.model_dump(exclude_none=True)
+    except Exception:
+        meta_dict = {
+            "name": seeder_class.__name__,
+            "description": seeder_class.__doc__,
+        }
+
+    meta_json = json.dumps(meta_dict, sort_keys=True, ensure_ascii=False)
+    sha.update(meta_json.encode("utf-8"))
+
+    return sha.hexdigest()
+

--- a/alembic-seeder/src/alembic_seeder/tracking/models.py
+++ b/alembic-seeder/src/alembic_seeder/tracking/models.py
@@ -34,6 +34,7 @@ class SeederRecord(Base):
     status = Column(String(20), nullable=False, default="completed")
     error_message = Column(Text, nullable=True)
     metadata_json = Column(Text, nullable=True)  # JSON string for additional metadata
+    content_hash = Column(String(64), nullable=True, index=True)
     
     def __repr__(self) -> str:
         return (


### PR DESCRIPTION
Implement content-hash tracking, `UpsertManager`, and CLI enhancements for robust idempotence and flexible seeder execution.

This PR addresses core requirements from the project guide, including "Idempotence by default" (via content-hash detection and `UpsertManager`), and "Command CLI" improvements (adding `--fresh` mode and enhanced `status` output). These changes enable the seeder system to intelligently detect modifications, skip up-to-date seeders, and offer more control over execution.

---
<a href="https://cursor.com/background-agent?bcId=bc-d27edee5-2bba-4896-b0d3-4899190ed400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d27edee5-2bba-4896-b0d3-4899190ed400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

